### PR TITLE
Add a "pass-through" return value for filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,8 +257,10 @@ Filters are merely classes that implement
 [`FilterInterface`](https://github.com/phergie/phergie-irc-plugin-react-eventfilter/blob/master/src/FilterInterface.php).
 This interface has a single method, `filter()`, which accepts an event object
 that implements [`EventInterface`](https://github.com/phergie/phergie-irc-event/blob/master/src/EventInterface.php)
-as its only parameter and returns `true` if the event should be allowed or
-`false` if it should not.
+as its only parameter and returns one of the following values:
+* `true` if the event should be allowed
+* `false` if the event should be denied
+* `null` if the event should be ignored by the filter ("pass-through")
 
 ## Tests
 

--- a/src/AndFilter.php
+++ b/src/AndFilter.php
@@ -24,16 +24,21 @@ class AndFilter extends CompositeFilter
      * Filters events that pass all contained filters.
      *
      * @param \Phergie\Irc\Event\EventInterface $event
-     * @return boolean TRUE if the event passes all contained filters, FALSE
-     *         otherwise
+     * @return boolean|null TRUE if the event passes all contained filters, FALSE
+     *         if it fails any filter, or NULL if all filters return NULL.
      */
     public function filter(EventInterface $event)
     {
+        $output = null;
         foreach ($this->filters as $filter) {
-            if (!$filter->filter($event)) {
+            $result = $filter->filter($event);
+            if ($result === false) {
                 return false;
             }
+            if ($result === true) {
+                $output = true;
+            }
         }
-        return true;
+        return $output;
     }
 }

--- a/src/ChannelFilter.php
+++ b/src/ChannelFilter.php
@@ -40,7 +40,7 @@ class ChannelFilter implements FilterInterface
     protected $parameters = array(
         'JOIN' => 'channels',
         'PART' => 'channels',
-        'MODE' => 'target',
+        'MODE' => 'channel',
         'TOPIC' => 'channel',
         'KICK' => 'channel',
         'PRIVMSG' => 'receivers',

--- a/src/ChannelFilter.php
+++ b/src/ChannelFilter.php
@@ -88,17 +88,21 @@ class ChannelFilter implements FilterInterface
      * channels.
      *
      * @param \Phergie\Irc\Event\EventInterface $event
-     * @return boolean TRUE if the event is not channel-specific or originated
-     *         from a matching channel associated with this filter, FALSE
-     *         otherwise
+     * @return boolean|null TRUE if the event originated from a matching channel
+     *         associated with this filter, FALSE if it originated from a non-matching
+     *         channel, or NULL if it is not associated with a channel.
      */
     public function filter(EventInterface $event)
     {
         if (!$event instanceof UserEventInterface) {
-            return true;
+            return null;
         }
 
         $channels = $this->getChannels($event);
+        if (empty($channels)) {
+            return null;
+        }
+
         $commonChannels = array_intersect($channels, $this->channels);
         if ($commonChannels) {
             return true;

--- a/src/FilterInterface.php
+++ b/src/FilterInterface.php
@@ -24,7 +24,9 @@ interface FilterInterface
      * Evaluates an event for forwarding.
      *
      * @param \Phergie\Irc\Event\EventInterface $event
-     * @return boolean TRUE if the event should be forwarded, FALSE otherwise
+     * @return boolean|null TRUE if the event should be allowed, FALSE if it should be rejected,
+     *         or NULL if it should be ignored (ie. the event does not fall under the scope of
+     *         this filter)
      */
     public function filter(EventInterface $event);
 }

--- a/src/NotFilter.php
+++ b/src/NotFilter.php
@@ -41,10 +41,15 @@ class NotFilter implements FilterInterface
      * Filters events that do not pass the contained filter.
      *
      * @param \Phergie\Irc\Event\EventInterface $event
-     * @return boolean TRUE if the contained filter fails, FALSE if it passes
+     * @return boolean|null TRUE if the contained filter fails, FALSE if it passes,
+     *         or NULL if it returns NULL.
      */
     public function filter(EventInterface $event)
     {
-        return !$this->filter->filter($event);
+        $result = $this->filter->filter($event);
+        if ($result === null) {
+            return null;
+        }
+        return !$result;
     }
 }

--- a/src/OrFilter.php
+++ b/src/OrFilter.php
@@ -24,16 +24,21 @@ class OrFilter extends CompositeFilter
      * Filters events that pass any contained filters.
      *
      * @param \Phergie\Irc\Event\EventInterface $event
-     * @return boolean TRUE if the event passes any contained filters, FALSE
-     *         otherwise
+     * @return boolean|null TRUE if the event passes any contained filters, FALSE
+     *         if it fails all filters, or NULL if all filters return NULL.
      */
     public function filter(EventInterface $event)
     {
+        $output = null;
         foreach ($this->filters as $filter) {
-            if ($filter->filter($event)) {
+            $result = $filter->filter($event);
+            if ($result === true) {
                 return true;
             }
+            if ($result === false) {
+                $output = false;
+            }
         }
-        return false;
+        return $output;
     }
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -165,7 +165,7 @@ class Plugin extends AbstractPlugin
             ));
         } else {
             $eventObject = reset($eventObjects);
-            if (!$this->filter->filter($eventObject)) {
+            if ($this->filter->filter($eventObject) === false) {
                 $logger->info('Event did not pass filter, skipping', array(
                     'event' => $event,
                     'args' => $args,

--- a/src/UserFilter.php
+++ b/src/UserFilter.php
@@ -45,18 +45,23 @@ class UserFilter implements FilterInterface
      * Filters events that are not user-specific or are from the specified users.
      *
      * @param \Phergie\Irc\Event\EventInterface $event
-     * @return boolean TRUE if the event is not user-specific or originated
-     *         from a user with a matching mask associated with this filter,
-     *         FALSE otherwise
+     * @return boolean|null TRUE if the event originated from a user with a matching mask
+     *         associated with this filter, FALSE if it originated from a user without a
+     *         matching mask, or NULL if it did not originate from a user.
      */
     public function filter(EventInterface $event)
     {
         if (!$event instanceof UserEventInterface) {
-            return true;
+            return null;
+        }
+
+        $nick = $event->getNick();
+        if ($nick === null) {
+            return null;
         }
 
         $userMask = sprintf('%s!%s@%s',
-            $event->getNick(),
+            $nick,
             $event->getUsername(),
             $event->getHost()
         );

--- a/src/UserModeFilter.php
+++ b/src/UserModeFilter.php
@@ -57,19 +57,23 @@ class UserModeFilter extends ChannelFilter
      * specified modes.
      *
      * @param \Phergie\Irc\Event\EventInterface $event
-     * @return boolean TRUE if the event is not user-specific or originated
-     *         from a user with a matching mode associated with this filter,
-     *         FALSE otherwise
+     * @return boolean|null TRUE if the event originated from a user with a matching mode
+     *         associated with this filter, FALSE if the event originated from a user
+     *         without a matching mode, or NULL if the event did not originate from a user.
      */
     public function filter(EventInterface $event)
     {
         if (!$event instanceof UserEventInterface) {
-            return true;
+            return null;
+        }
+
+        $channels = $this->getChannels($event);
+        $nick = $event->getNick();
+        if (empty($channels) || $nick === null) {
+            return null;
         }
 
         $connection = $event->getConnection();
-        $channels = $this->getChannels($event);
-        $nick = $event->getNick();
 
         foreach ($channels as $channel) {
             $userModes = $this->userMode->getUserModes($connection, $channel, $nick);

--- a/tests/AndFilterTest.php
+++ b/tests/AndFilterTest.php
@@ -35,6 +35,9 @@ class AndFilterTest extends \PHPUnit_Framework_TestCase
             array(true, false, false),
             array(false, true, false),
             array(true, true, true),
+            array(true, null, true),
+            array(false, null, false),
+            array(null, null, null),
         );
 
         foreach ($returns as $return) {

--- a/tests/ChannelFilterTest.php
+++ b/tests/ChannelFilterTest.php
@@ -47,7 +47,7 @@ class ChannelFilterTest extends \PHPUnit_Framework_TestCase
         $parameters = array(
             'JOIN' => 'channels',
             'PART' => 'channels',
-            'MODE' => 'target',
+            'MODE' => 'channel',
             'TOPIC' => 'channel',
             'KICK' => 'channel',
             'PRIVMSG' => 'receivers',

--- a/tests/ChannelFilterTest.php
+++ b/tests/ChannelFilterTest.php
@@ -54,7 +54,7 @@ class ChannelFilterTest extends \PHPUnit_Framework_TestCase
         );
 
         // Not an instance of UserEventInterface
-        $data[] = array(Phake::mock('\Phergie\Irc\Event\EventInterface'), true);
+        $data[] = array(Phake::mock('\Phergie\Irc\Event\EventInterface'), null);
 
         // Supported events in same channels as filter
         foreach (array('#channel1', '&channel2') as $channel) {
@@ -70,7 +70,7 @@ class ChannelFilterTest extends \PHPUnit_Framework_TestCase
         // Unsupported event
         $event = $this->getMockUserEvent();
         Phake::when($event)->getCommand()->thenReturn('QUIT');
-        $data[] = array($event, false);
+        $data[] = array($event, null);
 
         // Supported events in a different channel from the filter
         foreach ($parameters as $command => $parameter) {

--- a/tests/NotFilterTest.php
+++ b/tests/NotFilterTest.php
@@ -36,5 +36,8 @@ class NotFilterTest extends \PHPUnit_Framework_TestCase
 
         Phake::when($nestedFilter)->filter($event)->thenReturn(false);
         $this->assertTrue($filter->filter($event));
+
+        Phake::when($nestedFilter)->filter($event)->thenReturn(null);
+        $this->assertNull($filter->filter($event));
     }
 }

--- a/tests/OrFilterTest.php
+++ b/tests/OrFilterTest.php
@@ -37,6 +37,9 @@ class OrFilterTest extends \PHPUnit_Framework_TestCase
             array(true, false, true),
             array(false, true, true),
             array(true, true, true),
+            array(true, null, true),
+            array(false, null, false),
+            array(null, null, null),
         );
 
         foreach ($returns as $return) {

--- a/tests/UserFilterTest.php
+++ b/tests/UserFilterTest.php
@@ -32,7 +32,12 @@ class UserFilterTest extends \PHPUnit_Framework_TestCase
         $data = array();
 
         // Not an instance of UserEventInterface
-        $data[] = array(Phake::mock('\Phergie\Irc\Event\EventInterface'), true);
+        $data[] = array(Phake::mock('\Phergie\Irc\Event\EventInterface'), null);
+
+        // Not originating from a user
+        $event = Phake::mock('\Phergie\Irc\Event\UserEventInterface');
+        Phake::when($event)->getNick()->thenReturn(null);
+        $data[] = array($event, null);
 
         // Non-matching user mask
         $event = $this->getMockUserEvent('nick3', 'user3', 'host3');

--- a/tests/UserModeFilterTest.php
+++ b/tests/UserModeFilterTest.php
@@ -35,7 +35,18 @@ class UserModeFilterTest extends \PHPUnit_Framework_TestCase
 
         // Not an instance of UserEventInterface
         $userMode = $this->getMockUserModePlugin(array());
-        $data[] = array($userMode, Phake::mock('\Phergie\Irc\Event\EventInterface'), true);
+        $data[] = array($userMode, Phake::mock('\Phergie\Irc\Event\EventInterface'), null);
+
+        // Not originating from a user
+        $event = $this->getMockUserEvent();
+        Phake::when($event)->getNick()->thenReturn(null);
+        $data[] = array($userMode, $event, null);
+
+        // Not originating within a channel
+        $event = $this->getMockUserEvent();
+        Phake::when($event)->getCommand()->thenReturn('QUIT');
+        Phake::when($event)->getParams()->thenReturn([]);
+        $data[] = array($userMode, $event, null);
 
         // User does not have needed modes
         $event = $this->getMockUserEvent();


### PR DESCRIPTION
This changeset modifies the logic of the filter interface. Beforehand, filters were binary: either they allowed an event, or disallowed it. If an event did not fall under the scope of the filter (eg. a numeric server reply being passed to UserFilter), it returned "allow".

This led to peculiarities when using boolean filters. For example, using a UserFilter through a NotFilter, to disallow particular users from using a plugin, would also disallow all numeric server events. Similar quirks would occur with the composite logic filters.

To this end, this changeset gives filters ternary logic: as well as allow/deny, filters can now return an "ignore" value (`null`) which acts as a pass-through instruction to the event filter. If a filter returns `null`, it indicates that the event has not been disallowed, but it has not been explicitly allowed either. That means that it does not count as `true` for the purposes of AndFilter and OrFilter, and it is not affected by NotFilter. This prevents filters from accidentally (dis-)allowing events that aren't within their intended scope.

The ChannelFilter, UserFilter and UserModeFilter built-in filters now use this return value for appropriate events (eg. events that do not occur within a channel).

Also, a small fix for ChannelFilter which was listening to the wrong named parameter for the MODE command.