### PR TITLE
Forward set* calls to encapsulated plugins

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -10,10 +10,20 @@
 
 namespace Phergie\Irc\Plugin\React\EventFilter;
 
+use Evenement\EventEmitterInterface;
 use Phergie\Irc\Bot\React\AbstractPlugin;
+use Phergie\Irc\Bot\React\ClientAwareInterface;
+use Phergie\Irc\Bot\React\EventEmitterAwareInterface;
+use Phergie\Irc\Bot\React\EventQueueFactoryAwareInterface;
+use Phergie\Irc\Bot\React\EventQueueFactoryInterface;
 use Phergie\Irc\Bot\React\EventQueueInterface;
 use Phergie\Irc\Bot\React\PluginInterface;
+use Phergie\Irc\Client\React\ClientInterface;
+use Phergie\Irc\Client\React\LoopAwareInterface;
 use Phergie\Irc\Event\EventInterface;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerInterface;
+use React\EventLoop\LoopInterface;
 
 /**
  * Plugin for limiting processing of incoming events based on event metadata.
@@ -233,5 +243,80 @@ class Plugin extends AbstractPlugin
         }
 
         return $handlers;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setLogger(LoggerInterface $logger)
+    {
+        parent::setLogger($logger);
+        foreach ($this->plugins as $plugin) {
+            if (!($plugin instanceof LoggerAwareInterface)) {
+                continue;
+            }
+
+            $plugin->setLogger($logger);
+        }
+    }
+    
+    /**
+     * @inheritDoc
+     */
+    public function setEventEmitter(EventEmitterInterface $emitter)
+    {
+        parent::setEventEmitter($emitter);
+        foreach ($this->plugins as $plugin) {
+            if (!($plugin instanceof EventEmitterAwareInterface)) {
+                continue;
+            }
+
+            $plugin->setEventEmitter($emitter);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setClient(ClientInterface $client)
+    {
+        parent::setClient($client);
+        foreach ($this->plugins as $plugin) {
+            if (!($plugin instanceof ClientAwareInterface)) {
+                continue;
+            }
+
+            $plugin->setClient($client);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setEventQueueFactory(EventQueueFactoryInterface $queueFactory)
+    {
+        parent::setEventQueueFactory($queueFactory);
+        foreach ($this->plugins as $plugin) {
+            if (!($plugin instanceof EventQueueFactoryAwareInterface)) {
+                continue;
+            }
+
+            $plugin->setEventQueueFactory($queueFactory);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setLoop(LoopInterface $loop)
+    {
+        parent::setLoop($loop);
+        foreach ($this->plugins as $plugin) {
+            if (!($plugin instanceof LoopAwareInterface)) {
+                continue;
+            }
+
+            $plugin->setLoop($loop);
+        }
     }
 }

--- a/tests/PluginTest.php
+++ b/tests/PluginTest.php
@@ -306,6 +306,39 @@ class PluginTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Test that all set* calls are forwarded to encapsulated plugins.
+     */
+    public function testSetForwarding()
+    {
+        $mockedPlugin = Phake::mock('Phergie\Irc\Bot\React\AbstractPlugin');
+
+        $plugin = new Plugin(array(
+            'plugins' => array($mockedPlugin),
+            'filter' => $this->getMockFilter(),
+        ));
+
+        $logger = Phake::mock('Psr\Log\LoggerInterface');
+        $emitter = Phake::mock('Evenement\EventEmitterInterface');
+        $client = Phake::mock('Phergie\Irc\Client\React\ClientInterface');
+        $queueFactory = Phake::mock('Phergie\Irc\Bot\React\EventQueueFactoryInterface');
+        $loop = Phake::mock('React\EventLoop\LoopInterface');
+
+        $plugin->setLogger($logger);
+        $plugin->setEventEmitter($emitter);
+        $plugin->setClient($client);
+        $plugin->setEventQueueFactory($queueFactory);
+        $plugin->setLoop($loop);
+
+        Phake::inOrder(
+            Phake::verify($mockedPlugin)->setLogger($logger),
+            Phake::verify($mockedPlugin)->setEventEmitter($emitter),
+            Phake::verify($mockedPlugin)->setClient($client),
+            Phake::verify($mockedPlugin)->setEventQueueFactory($queueFactory),
+            Phake::verify($mockedPlugin)->setLoop($loop)
+        );
+    }
+
+    /**
      * Returns a mock plugin.
      *
      * @return \Phergie\Irc\Bot\React\PluginInterface


### PR DESCRIPTION
When a plugin is only used with a filtered context the loop, logger, etc are never set because those calls aren't forwarded to the encapsulated plugins.

Todo:
- [x] Add missing set methods
- [x] Add tests