### PR TITLE
dropped php 5.5 and added 7.1; allow_failures for hhvm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,14 @@
 language: php
 
 php:
-  - 5.5
   - 5.6
   - 7.0
+  - 7.1
   - hhvm
+
+matrix:
+  allow_failures:
+    - php: hhvm
 
 before_script:
   - composer self-update


### PR DESCRIPTION
dropped php 5.5 and added php 7.1
added allow_failures to `.travis.yml`

resolves #7 