### PR TITLE
Implement Caseless & Cased matching of masks - Issue #10

### DIFF
--- a/src/UserFilter.php
+++ b/src/UserFilter.php
@@ -78,6 +78,7 @@ class UserFilter implements FilterInterface
 
         foreach ($this->masks as $mask) {
             $pattern = '/^' . str_replace('*', '.*', $mask) . '$/';
+
             if ($this->caseless) {
                 $pattern .= "i";
             }

--- a/src/UserFilter.php
+++ b/src/UserFilter.php
@@ -28,7 +28,7 @@ class UserFilter implements FilterInterface
      *
      * @var boolean
      */
-    protected $caseless = true;
+    protected $caseless = false;
 
     /**
      * List of masks identifying users from whom to forward events
@@ -43,27 +43,17 @@ class UserFilter implements FilterInterface
     const ERR_CASELESS_BOOLEAN = 1;
 
     /**
-     * Exception code used when masks are not set or not set as an array
-     */
-    const ERR_MASKS_NONARRAY = 2;
-
-    /**
      * Accepts filter configuration.
      *
-     * Supported keys:
-     *
-     * masks - an array of masks identifying users from whom to forward events
-     *
-     * caseless - true to use the caseless preg modifier when comparing masks,
-     * true by default
-     *
-     * @param array $config
+     * @param array $masks An array of masks identifying users from whom to forward events
+     * @param boolean $caseless True to use the caseless preg modifier when comparing masks,
+     *        false by default
      * @see http://www.ircbeginner.com/opvinfo/masks.html
      */
-    public function __construct(array $config)
+    public function __construct(array $masks, $caseless = false)
     {
-        $this->caseless = $this->getCaseless($config);
-        $this->masks = $this->getMasks($config);
+        $this->masks = $masks;
+        $this->caseless = $caseless;
     }
 
     /**
@@ -103,47 +93,5 @@ class UserFilter implements FilterInterface
         }
 
         return false;
-    }
-
-    /**
-     * Validates and extracts caseless from configuration
-     *
-     * @param array $config
-     * @return boolean
-     * @throws \RuntimeException Configuration doesn't specify caseless as boolean
-     */
-    protected function getCaseless(array $config)
-    {
-        if (isset($config['caseless'])) {
-            if (!is_bool($config['caseless'])) {
-                throw new \RuntimeException(
-                    'Configuration that contains the "caseless" key must reference a boolean',
-                    self::ERR_CASELESS_BOOLEAN
-                );
-            }
-
-            return $config['caseless'];
-        }
-
-        return $this->caseless;
-    }
-
-    /**
-     * Validates and extracts masks from configuration
-     *
-     * @param array $config
-     * @return array
-     * @throws \RuntimeException Configuration lacks an array of masks
-     */
-    protected function getMasks(array $config)
-    {
-        if (!isset($config['masks']) || !is_array($config['masks'])) {
-            throw new \RuntimeException(
-                'Configuration must contain the "masks" key and reference an array',
-                self::ERR_MASKS_NONARRAY
-            );
-        }
-
-        return $config['masks'];
     }
 }

--- a/src/UserFilter.php
+++ b/src/UserFilter.php
@@ -38,11 +38,6 @@ class UserFilter implements FilterInterface
     protected $masks = [];
 
     /**
-     * Exception code used when caseless is not set as a boolean
-     */
-    const ERR_CASELESS_BOOLEAN = 1;
-
-    /**
      * Accepts filter configuration.
      *
      * @param array $masks An array of masks identifying users from whom to forward events
@@ -53,7 +48,7 @@ class UserFilter implements FilterInterface
     public function __construct(array $masks, $caseless = false)
     {
         $this->masks = $masks;
-        $this->caseless = $caseless;
+        $this->caseless = (bool) $caseless;
     }
 
     /**

--- a/src/UserFilter.php
+++ b/src/UserFilter.php
@@ -28,17 +28,29 @@ class UserFilter implements FilterInterface
      *
      * @var array
      */
-    protected $masks;
+    protected $masks = [];
 
     /**
-     * Accepts a list of masks identifying users from whom to forward events.
+     * Exception code used when masks are not set or not set as an array
+     */
+    const ERR_MASKS_NONARRAY = 1;
+
+    /**
+     * Accepts filter configuration.
      *
-     * @param array $masks
+     * Supported keys:
+     *
+     * masks - an array of masks identifying users from whom to forward events
+     *
+     * caseless - true to use the caseless preg modifier when comparing masks,
+     * true by default
+     *
+     * @param array $config
      * @see http://www.ircbeginner.com/opvinfo/masks.html
      */
-    public function __construct(array $masks)
+    public function __construct(array $config)
     {
-        $this->masks = $masks;
+        $this->masks = $this->getMasks($config);
     }
 
     /**
@@ -74,5 +86,24 @@ class UserFilter implements FilterInterface
         }
 
         return false;
+    }
+
+    /**
+     * Validates and extracts masks from configuration
+     *
+     * @param array $config
+     * @return array
+     * @throws \RuntimeException Configuration lacks an array of masks
+     */
+    protected function getMasks(array $config)
+    {
+        if (!isset($config['masks']) || !is_array($config['masks'])) {
+            throw new \RuntimeException(
+                'Configuration must contain the "masks" key and reference an array',
+                self::ERR_MASKS_NONARRAY
+            );
+        }
+
+        return $config['masks'];
     }
 }

--- a/tests/UserFilterTest.php
+++ b/tests/UserFilterTest.php
@@ -89,38 +89,6 @@ class UserFilterTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Data provider for testInvalidConfiguration().
-     *
-     * @return array
-     */
-    public function dataProviderInvalidConfiguration()
-    {
-        $data = [];
-
-        $data[] = [
-            [
-                'caseless' => 'not a boolean',
-                'masks' => []
-            ],
-            UserFilter::ERR_CASELESS_BOOLEAN,
-        ];
-
-        $data[] = [
-            [],
-            UserFilter::ERR_MASKS_NONARRAY,
-        ];
-
-        $data[] = [
-            [
-                'masks' => 'not an array'
-            ],
-            UserFilter::ERR_MASKS_NONARRAY,
-        ];
-
-        return $data;
-    }
-
-    /**
      * Tests filter().
      *
      * @param \Phergie\Irc\Event\EventInterface $event
@@ -129,7 +97,7 @@ class UserFilterTest extends \PHPUnit_Framework_TestCase
      */
     public function testFilter(EventInterface $event, $expected)
     {
-        $filter = new UserFilter(['masks' => ['nick1!user1@host1', 'nick2*!user2*@host2*']]);
+        $filter = new UserFilter($masks = ['nick1!user1@host1', 'nick2*!user2*@host2*']);
         $this->assertSame($expected, $filter->filter($event));
     }
 
@@ -142,7 +110,7 @@ class UserFilterTest extends \PHPUnit_Framework_TestCase
      */
     public function testFilterCaseless(EventInterface $event, $expected)
     {
-        $filter = new UserFilter(['masks' => ['nick1!user1@host1'], ['caseless' => true]]);
+        $filter = new UserFilter($masks = ['nick1!user1@host1'], $caseless = true);
         $this->assertSame($expected, $filter->filter($event));
     }
 
@@ -155,25 +123,8 @@ class UserFilterTest extends \PHPUnit_Framework_TestCase
      */
     public function testFilterCased(EventInterface $event, $expected)
     {
-        $filter = new UserFilter(['masks' => ['nick1!user1@host1'], 'caseless' => false]);
+        $filter = new UserFilter($masks = ['nick1!user1@host1'], $caseless = false);
         $this->assertSame($expected, $filter->filter($event));
-    }
-
-    /**
-     * Tests that invalid configurations throw exceptions.
-     *
-     * @param array $config Configuration to apply
-     * @param int $code Expected exception code
-     * @dataProvider dataProviderInvalidConfiguration
-     */
-    public function testInvalidConfiguration(array $config, $code)
-    {
-        try {
-            $filter = new UserFilter($config);
-            $this->fail('Expected exception was not thrown');
-        } catch (\RuntimeException $e) {
-            $this->assertSame($code, $e->getCode());
-        }
     }
 
     /**

--- a/tests/UserFilterTest.php
+++ b/tests/UserFilterTest.php
@@ -53,6 +53,42 @@ class UserFilterTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Data provider for testFilterCaseless().
+     *
+     * @return array
+     */
+    public function dataProviderFilterCaseless()
+    {
+        $data = [];
+
+        $event = $this->getMockUserEvent('nick1', 'user1', 'host1');
+        $data[] = [$event, true];
+
+        $event = $this->getMockUserEvent('NICK1', 'USER1', 'HOST1');
+        $data[] = [$event, true];
+
+        return $data;
+    }
+
+    /**
+     * Data provider for testFilterCased().
+     *
+     * @return array
+     */
+    public function dataProviderFilterCased()
+    {
+        $data = [];
+
+        $event = $this->getMockUserEvent('nick1', 'user1', 'host1');
+        $data[] = [$event, true];
+
+        $event = $this->getMockUserEvent('NICK1', 'USER1', 'HOST1');
+        $data[] = [$event, false];
+
+        return $data;
+    }
+
+    /**
      * Data provider for testInvalidConfiguration().
      *
      * @return array
@@ -60,6 +96,15 @@ class UserFilterTest extends \PHPUnit_Framework_TestCase
     public function dataProviderInvalidConfiguration()
     {
         $data = [];
+
+        $data[] = [
+            [
+                'caseless' => 'not a boolean',
+                'masks' => []
+            ],
+            UserFilter::ERR_CASELESS_BOOLEAN,
+        ];
+
         $data[] = [
             [],
             UserFilter::ERR_MASKS_NONARRAY,
@@ -88,6 +133,31 @@ class UserFilterTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($expected, $filter->filter($event));
     }
 
+    /**
+     * Tests matching caseless masks.
+     *
+     * @param \Phergie\Irc\Event\EventInterface $event
+     * @param boolean $expected
+     * @dataProvider dataProviderFilterCaseless
+     */
+    public function testFilterCaseless(EventInterface $event, $expected)
+    {
+        $filter = new UserFilter(['masks' => ['nick1!user1@host1'], ['caseless' => true]]);
+        $this->assertSame($expected, $filter->filter($event));
+    }
+
+    /**
+     * Tests matching cased masks.
+     *
+     * @param \Phergie\Irc\Event\EventInterface $event
+     * @param boolean $expected
+     * @dataProvider dataProviderFilterCased
+     */
+    public function testFilterCased(EventInterface $event, $expected)
+    {
+        $filter = new UserFilter(['masks' => ['nick1!user1@host1'], 'caseless' => false]);
+        $this->assertSame($expected, $filter->filter($event));
+    }
 
     /**
      * Tests that invalid configurations throw exceptions.


### PR DESCRIPTION
This pull request breaks backwards compatibility.

Resolves #10 

Implements case insensitive & case sensitive matching of masks.

* Changes format of $config, this is the BC breaking change
* `masks` is now a key of the $config array instead of **_being_** the array
* added new optional $config key `caseless`
* Case insensitive matching by default `'caseless' = true`
* Case sensitive matching by setting `'caseless' = false`

EDIT: Preserved backwards compatibility per elazar's request.