### PR TITLE
Use preg_quote on masks.

### DIFF
--- a/src/UserFilter.php
+++ b/src/UserFilter.php
@@ -77,7 +77,7 @@ class UserFilter implements FilterInterface
         );
 
         foreach ($this->masks as $mask) {
-            $pattern = '/^' . str_replace('*', '.*', $mask) . '$/';
+            $pattern = '/^' . str_replace('\*', '.*', preg_quote($mask, '/')) . '$/';
 
             if ($this->caseless) {
                 $pattern .= "i";

--- a/tests/UserFilterTest.php
+++ b/tests/UserFilterTest.php
@@ -49,6 +49,10 @@ class UserFilterTest extends \PHPUnit_Framework_TestCase
             $data[] = [$event, true];
         }
 
+        // Matching freenode style mask
+        $event = $this->getMockUserEvent('freenodenick', 'freenodeuser', 'unaffiliated/freenodenick');
+        $data[] = [$event, true];
+
         return $data;
     }
 
@@ -97,7 +101,11 @@ class UserFilterTest extends \PHPUnit_Framework_TestCase
      */
     public function testFilter(EventInterface $event, $expected)
     {
-        $filter = new UserFilter($masks = ['nick1!user1@host1', 'nick2*!user2*@host2*']);
+        $filter = new UserFilter($masks = [
+            'nick1!user1@host1',
+            'nick2*!user2*@host2*',
+            'freenodenick!freenodeuser@unaffiliated/freenodenick'
+        ]);
         $this->assertSame($expected, $filter->filter($event));
     }
 


### PR DESCRIPTION
- Freenode allows `/` in user masks. If you pass a freenode mask without a
wildcard to `UserFilter`, `preg_match` will likely generate an unknown modifier
warning because the pattern will be delimited in the wrong place. Even
if no warning is generated the pattern will be incorrect.
- Preserves behavior of the `*` wildcard.
- Thanks to freestyledork on Freenode for discovering this behavior.